### PR TITLE
fixing  cannot unmarshal object into Go struct field CopilotAssigneeTeam.seats.assigning_team.parent of type string 

### DIFF
--- a/internal/github/models.go
+++ b/internal/github/models.go
@@ -67,20 +67,24 @@ type CopilotAssignee struct {
 }
 
 type CopilotAssigneeTeam struct {
-	Id                   int    `json:"id,omitempty"`
-	NodeId               string `json:"node_id,omitempty"`
-	URL                  string `json:"url,omitempty"`
-	HtmlURL              string `json:"html_url,omitempty"`
-	Name                 string `json:"name,omitempty"`
-	Slug                 string `json:"slug,omitempty"`
-	Description          string `json:"description,omitempty"`
-	Privacy              string `json:"privacy,omitempty"`
-	NotificationSettings string `json:"notification_setting,omitempty"`
-	Permission           string `json:"permission,omitempty"`
-	Email                string `json:"email,omitempty"`
-	MembersURL           string `json:"members_url,omitempty"`
-	RepositoriesURL      string `json:"repositories_url,omitempty"`
-	Parent               string `json:"parent,omitempty"`
+	Id                   int        `json:"id,omitempty"`
+	NodeId               string     `json:"node_id,omitempty"`
+	URL                  string     `json:"url,omitempty"`
+	HtmlURL              string     `json:"html_url,omitempty"`
+	Name                 string     `json:"name,omitempty"`
+	Slug                 string     `json:"slug,omitempty"`
+	Description          string     `json:"description,omitempty"`
+	Privacy              string     `json:"privacy,omitempty"`
+	NotificationSettings string     `json:"notification_setting,omitempty"`
+	Permission           string     `json:"permission,omitempty"`
+	Email                string     `json:"email,omitempty"`
+	MembersURL           string     `json:"members_url,omitempty"`
+	RepositoriesURL      string     `json:"repositories_url,omitempty"`
+	Parent               ParentType `json:"parent,omitempty"`
+}
+type ParentType struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 type CopilotBillingSeats struct {


### PR DESCRIPTION
we were getting this error while trying to scrape github copilot with `is_enterprise: yes`


`Failed to get Copilot billing: failed to decode JSON response: json: cannot unmarshal object into Go struct field CopilotAssigneeTeam.seats.assigning_team.parent of type string`

the resonse we are getting is something like: 

`Parent:{ID:XXXX Name:XXX}}`


