### PR TITLE
Fix casing to prevent exception

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -45,14 +45,14 @@ func GetTotalActiveUsers(usage github.CopilotUsage) float64 {
 	return float64(usage.TotalActiveUsers)
 }
 
-func getTotalChatAcceptances(usage github.CopilotUsage) float64 {
+func GetTotalChatAcceptances(usage github.CopilotUsage) float64 {
     return float64(usage.TotalChatAcceptance)
 }
 
-func getTotalChatTurns(usage github.CopilotUsage) float64 {
+func GetTotalChatTurns(usage github.CopilotUsage) float64 {
     return float64(usage.TotalChatTurns)
 }
 
-func getTotalActiveChatUsers(usage github.CopilotUsage) float64 {
+func GetTotalActiveChatUsers(usage github.CopilotUsage) float64 {
     return float64(usage.TotalActiveChatUsers)
 }


### PR DESCRIPTION
I've accidently added functions with wrong casing so it threw exceptions. now it's fixed.